### PR TITLE
Add name to device labels

### DIFF
--- a/nutcollector/collector.go
+++ b/nutcollector/collector.go
@@ -97,7 +97,7 @@ func New(hosts []string) prometheus.Collector {
 		descs[k] = prometheus.NewDesc(
 			prometheus.BuildFQName(namespace, "", v.name),
 			v.desc,
-			[]string{"model", "mfr", "serial", "type"},
+			[]string{"name", "model", "mfr", "serial", "type"},
 			nil,
 		)
 	}
@@ -192,7 +192,7 @@ func (c *nutCollector) readNUT(conn *nut.Client, name string, ch chan<- promethe
 	}
 
 	labelValues := []string{
-		labels["device.model"], labels["device.mfr"], labels["device.serial"], labels["device.type"],
+		name, labels["device.model"], labels["device.mfr"], labels["device.serial"], labels["device.type"],
 	}
 
 	for k, v := range values {


### PR DESCRIPTION
Some UPSes report little or no device identification info. Add the user-configurable UPS name which is more likely to be useful in these cases.

From:
```
nut_battery_voltage_volts{mfr="",model="",serial="",type="ups"} 109
nut_battery_voltage_volts{mfr="",model="G10K",serial="",type="ups"} 273.2
```
To:
```
nut_battery_voltage_volts{mfr="",model="",name="ups1",serial="",type="ups"} 109
nut_battery_voltage_volts{mfr="",model="G10K",name="ups2",serial="",type="ups"} 273.2
```